### PR TITLE
fix: align vision and values cards in a single row

### DIFF
--- a/Html/about.html
+++ b/Html/about.html
@@ -79,7 +79,7 @@
         </div>
       </div>
       <div class="row g-4 justify-content-center">
-        <div class="col-md-8" data-animate="fade-up">
+        <div class="col-md-12" data-animate="fade-up">
           <div class="vision-box large">
             <h5>Our Vision</h5>
             <p class="mb-0">To build a resilient, connected, and empowered multicultural community in Western Australia where everyone has access to support in their time of need.</p>


### PR DESCRIPTION
Changed col-md-8 to col-12 on the vision box in about.html 
so all three value cards (Compassion, Cultural Respect, Community) 
appear in one row instead of wrapping to the next line.