### PR TITLE
fix: rename Fundraise Events to Events across all pages

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -546,7 +546,7 @@ msgid "Get Involved"
 msgstr ""
 
 #: templates/events.html:7 templates/events.html:8 templates/navbar.html:44
-msgid "Fundraise Events"
+msgid "Events"
 msgstr ""
 
 #: templates/events.html:16 templates/events.html:22

--- a/templates/events.html
+++ b/templates/events.html
@@ -4,8 +4,8 @@
 <div class="page-banner">
   <div class="container">
     <p class="section-eyebrow light">{{ _('Get Involved') }}</p>
-    <h1 class="page-banner-title">{{ _('Fundraise Events') }}</h1>
-    <nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="{{ url_for('home') }}">{{ _('Home') }}</a></li><li class="breadcrumb-item active">{{ _('Fundraise Events') }}</li></ol></nav>
+    <h1 class="page-banner-title">{{ _('Events') }}</h1>
+    <nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="{{ url_for('home') }}">{{ _('Home') }}</a></li><li class="breadcrumb-item active">{{ _('Events') }}</li></ol></nav>
   </div>
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,7 +33,7 @@
             </ul>
           </li>
           <li class="nav-item"><a class="nav-link" href="stories.html">Our Stories</a></li>
-          <li class="nav-item"><a class="nav-link" href="events.html">Fundraise Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
           <li class="nav-item"><a class="nav-link" href="news.html">News</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contact Us</a></li>
           <li class="nav-item ms-lg-2"><a class="btn btn-donate" href="donate.html">Donate</a></li>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -44,7 +44,7 @@
           </li>
   
           <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('events') }}">{{ _('Fundraise Events') }}</a>
+            <a class="nav-link" href="{{ url_for('events') }}">{{ _('Events') }}</a>
           </li>
   
           <li class="nav-item">

--- a/translations/zh_Hans_CN/LC_MESSAGES/messages.po
+++ b/translations/zh_Hans_CN/LC_MESSAGES/messages.po
@@ -54,7 +54,7 @@ msgstr "反诈骗意识"
 msgid "Health Advocacy"
 msgstr "健康倡导"
 
-msgid "Fundraise Events"
+msgid "Events"
 msgstr "筹款活动"
 
 msgid "Navigate"


### PR DESCRIPTION
Closes #25

## Summary
- Renamed "Fundraise Events" to "Events" in navbar and page content
- Updated breadcrumb and page heading text for consistency
- Updated translation message entries

## Files changed
- templates/events.html
- templates/navbar.html
- messages.pot