### PR TITLE
feat: add ACNC logo to donate page

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -15,7 +15,15 @@
       <div class="col-lg-7" data-animate="fade-up">
         <p class="section-eyebrow">{{ _('Your Impact') }}</p>
         <h2 class="section-heading">{{ _('Why Your Donation Matters') }}</h2>
-        <p class="section-body">{{ _('Every dollar donated directly supports CALD individuals and families in Western Australia when they need it most.') }}</p>
+        <p class="section-body mb-4">{{ _('Every dollar donated directly supports CALD individuals and families in Western Australia when they need it most.') }}</p>
+        <div class="text-center mt-4">
+          <img
+            src="https://static.wixstatic.com/media/848b67_6e855971355b428b9e360cd85d651ff0~mv2.png"
+            alt="ACNC Registered Charity"
+            class="img-fluid"
+            style="max-width: 130px;"
+          >
+        </div>
       </div>
     </div>
     <div class="row g-4 mb-5">


### PR DESCRIPTION
Closes #27

## Summary
- Added ACNC Registered Charity logo to the donate page
- Placed the logo below the "Why Your Donation Matters" heading
- Ensured the logo stays responsive on smaller screens

## Files changed
- templates/donate.html