### PR TITLE
fix: resolve forgot password back to login 404

### DIFF
--- a/templates/forgot-password.html
+++ b/templates/forgot-password.html
@@ -5,7 +5,7 @@
     <div class="container">
       <p class="section-eyebrow light">Account Recovery</p>
       <h1 class="page-banner-title">Forgot Password</h1>
-      <nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="index.html">Home</a></li><li class="breadcrumb-item"><a href="volunteer.html">Volunteer</a></li><li class="breadcrumb-item active">Forgot Password</li></ol></nav>
+      <nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="{{ url_for('home') }}">Home</a></li><li class="breadcrumb-item"><a href="{{ url_for('volunteer') }}">Volunteer</a></li><li class="breadcrumb-item active">Forgot Password</li></ol></nav>
     </div>
   </div>
 
@@ -46,7 +46,7 @@
               </div>
               <h4 style="font-family:var(--ff-heading); color:var(--clr-dark);">Check Your Email</h4>
               <p style="color:var(--clr-muted);">We've sent a password reset link to your email address. Please check your inbox and follow the instructions.</p>
-              <a href="volunteer.html" class="btn btn-primary-green mt-3">Back to Login <i class="bi bi-arrow-right ms-1"></i></a>
+              <a href="{{ url_for('volunteer') }}" class="btn btn-primary-green mt-3">Back to Login <i class="bi bi-arrow-right ms-1"></i></a>
             </div>
           </div>
 
@@ -59,8 +59,8 @@
     <div class="container">
       <div class="row g-4 align-items-start">
         <div class="col-lg-4"><div class="d-flex align-items-center gap-2 mb-3"><img src="https://static.wixstatic.com/media/848b67_6e855971355b428b9e360cd85d651ff0~mv2.png/v1/fill/w_172,h_179,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/848b67_6e855971355b428b9e360cd85d651ff0~mv2.png" alt="WMAA" height="50" /><span class="footer-brand">WMAA</span></div><p class="footer-tagline">Join Us in Our Mission</p><p class="footer-small">Company Limited by Guarantee<br />ACNC Registered Charity</p></div>
-        <div class="col-lg-2 col-6"><h6 class="footer-heading">Navigate</h6><ul class="footer-links"><li><a href="index.html">Home</a></li><li><a href="about.html">About Us</a></li><li><a href="services.html">Services</a></li><li><a href="stories.html">Our Stories</a></li><li><a href="events.html">Events</a></li><li><a href="news.html">News</a></li><li><a href="contact.html">Contact Us</a></li></ul></div>
-        <div class="col-lg-3 col-6"><h6 class="footer-heading">Services</h6><ul class="footer-links"><li><a href="services.html#crisis">Crisis Response</a></li><li><a href="services.html#mediation">Cultural Mediation</a></li><li><a href="services.html#housing">Housing Referrals</a></li><li><a href="services.html#fraud">Fraud Awareness</a></li><li><a href="services.html#health">Health Advocacy</a></li></ul></div>
+        <div class="col-lg-2 col-6"><h6 class="footer-heading">Navigate</h6><ul class="footer-links"><li><a href="{{ url_for('home') }}">Home</a></li><li><a href="{{ url_for('about') }}">About Us</a></li><li><a href="{{ url_for('services') }}">Services</a></li><li><a href="{{ url_for('stories') }}">Our Stories</a></li><li><a href="{{ url_for('events') }}">Events</a></li><li><a href="{{ url_for('news') }}">News</a></li><li><a href="{{ url_for('contact') }}">Contact Us</a></li></ul></div>
+        <div class="col-lg-3 col-6"><h6 class="footer-heading">Services</h6><ul class="footer-links"><li><a href="{{ url_for('services') }}#crisis">Crisis Response</a></li><li><a href="{{ url_for('services') }}#mediation">Cultural Mediation</a></li><li><a href="{{ url_for('services') }}#housing">Housing Referrals</a></li><li><a href="{{ url_for('services') }}#fraud">Fraud Awareness</a></li><li><a href="{{ url_for('services') }}#health">Health Advocacy</a></li></ul></div>
         <div class="col-lg-3"><h6 class="footer-heading">Contact</h6><ul class="footer-links"><li><i class="bi bi-geo-alt"></i> 10 Lake Street, Northbridge, Perth WA</li><li><i class="bi bi-envelope"></i> <a href="mailto:admin@wmaacharity.com.au">admin@wmaacharity.com.au</a></li><li><i class="bi bi-telephone"></i> (61) 86555 7072</li></ul></div>
       </div>
       <hr class="footer-divider" />


### PR DESCRIPTION
Closes #24

Fixed the Back to Login button on the forgot password confirmation screen.

Changes:
- Replaced hardcoded volunteer.html link with Flask url_for('volunteer')
- Updated breadcrumb links to use Flask routes
- Updated footer links to use Flask routes

Testing:
- Verified /forgot-password loads correctly
- Verified Send Reset Link shows confirmation screen
- Verified Back to Login redirects to /volunteer without 404